### PR TITLE
Addition of If-Then-Else Example + For-Loop Example

### DIFF
--- a/tools/liquidTypes-varibleEnvLib-example/CMakeLists.txt
+++ b/tools/liquidTypes-varibleEnvLib-example/CMakeLists.txt
@@ -22,5 +22,7 @@ set(LLVM_NO_DEAD_STRIP 1)
 add_llvm_tool(liquidTypes-varibleEnvLib-example
   VariableEnvLib.cpp
   VariableEnvLib_IfExample.cpp
+  VariableEnvLib_IfTwoExample.cpp
+  VariableEnvLib_LoopExample.cpp
   )
 export_executable_symbols(liquidTypes-varibleEnvLib-example)

--- a/tools/liquidTypes-varibleEnvLib-example/CMakeLists.txt
+++ b/tools/liquidTypes-varibleEnvLib-example/CMakeLists.txt
@@ -22,7 +22,7 @@ set(LLVM_NO_DEAD_STRIP 1)
 add_llvm_tool(liquidTypes-varibleEnvLib-example
   VariableEnvLib.cpp
   VariableEnvLib_IfExample.cpp
-  VariableEnvLib_IfTwoExample.cpp
-  VariableEnvLib_LoopExample.cpp
-  )
+  VariableEnvLib_IfExampleTwo.cpp
+  VariableEnvLib_LoopExample.cpp  
+)
 export_executable_symbols(liquidTypes-varibleEnvLib-example)

--- a/tools/liquidTypes-varibleEnvLib-example/VariableEnvLib.cpp
+++ b/tools/liquidTypes-varibleEnvLib-example/VariableEnvLib.cpp
@@ -19,6 +19,8 @@ std::string format(VariablesEnvironment& env, std::string expression)
 }
 
 int ifExample();
+int ifThenElseExample();
+int forLoopExample();
 
 int main()
 {
@@ -26,12 +28,21 @@ int main()
 	std::cout << "Enter a number" << std::endl;
 	std::cout << "1 for example with if" << std::endl;
 	std::cout << "2 for example with if else" << std::endl;
+	std::cout << "3 for example with for loop" << std::endl;
 	std::cout << "Choice: ";
 	std::cin >> a;
 
 	if(a == 1)
 	{
 		return ifExample();
+	}
+        else if(a == 2)
+	{
+		return ifTheElseExample();
+	}
+	else if(a == 3)
+	{
+		return forLoopExample();
 	}
 	else
 	{

--- a/tools/liquidTypes-varibleEnvLib-example/VariableEnvLib.cpp
+++ b/tools/liquidTypes-varibleEnvLib-example/VariableEnvLib.cpp
@@ -38,7 +38,7 @@ int main()
 	}
         else if(a == 2)
 	{
-		return ifTheElseExample();
+		return ifThenElseExample();
 	}
 	else if(a == 3)
 	{

--- a/tools/liquidTypes-varibleEnvLib-example/VariableEnvLib_IfExample.cpp
+++ b/tools/liquidTypes-varibleEnvLib-example/VariableEnvLib_IfExample.cpp
@@ -91,3 +91,8 @@ errh:
   std::cout << "Failed:" << std::endl << str;
   return -1;
 }
+
+int main()
+{
+  ifExample();
+}

--- a/tools/liquidTypes-varibleEnvLib-example/VariableEnvLib_IfExample.cpp
+++ b/tools/liquidTypes-varibleEnvLib-example/VariableEnvLib_IfExample.cpp
@@ -91,8 +91,3 @@ errh:
   std::cout << "Failed:" << std::endl << str;
   return -1;
 }
-
-int main()
-{
-  ifExample();
-}

--- a/tools/liquidTypes-varibleEnvLib-example/VariableEnvLib_IfExampleTwo.cpp
+++ b/tools/liquidTypes-varibleEnvLib-example/VariableEnvLib_IfExampleTwo.cpp
@@ -1,0 +1,128 @@
+#include "llvm/Transforms/LiquidTypes/VariablesEnvironment.h"
+#include "llvm/Transforms/LiquidTypes/FunctionBlockgraph.h"
+#include "llvm/Transforms/LiquidTypes/ResultType.h"
+#include <regex>
+#include <iostream>
+
+using namespace liquid;
+using namespace std::literals::string_literals;
+
+class LLVMFunctionBlockGraph_IfTwo: public FunctionBlockGraph
+{
+public:
+  std::string GetStartingBlockName() const
+  {
+    return "entry"s;
+  }
+
+  ResultType GetSuccessorBlocks(const std::string& blockName, std::vector<std::string>& successorBlocks) const
+  {
+    if (blockName == "entry")
+    {
+      successorBlocks.emplace_back("if.then");
+      successorBlocks.emplace_back("if.end");
+    }
+    else if (blockName == "if.then")
+    {
+      successorBlocks.emplace_back("if.end");
+    }
+    else if (blockName == "if.end")
+    {
+      
+    }   
+    else
+    {
+      return ResultType::Error("NA");
+    }
+
+    return ResultType::Success();
+  }
+
+  ResultType StrictlyDominates(const std::string& firstblockName, const std::string& secondBlockName, bool& result) const
+  {
+    result = (firstblockName == "entry" && secondBlockName != "entry");
+    return ResultType::Success();
+  }
+};
+
+std::string format(VariablesEnvironment& env, std::string expression);
+
+#define E(exp) \
+{\
+  ResultType a = exp; \
+  if (!a.Succeeded) { str = a.ErrorMsg goto errh;}\
+}
+
+int ifThenElseExample()
+{
+  /* Code to Verify :
+     int a = 4;
+     int b;
+     if (a == 4) { b = 5; } else { b = 6; }
+     int b {__value == 5}
+  */
+  LLVMFunctionBlockGraph_If llvmFunctionBlockGraph;
+  Variablesenvironment env(llvmFunctionBlockGraph);
+
+  std::string str;
+
+  /* Corresponding 3-address code :
+     int a = 4;
+     int b;
+     if (a == 4) goto {{ return 5; }}
+     return 6;
+     goto {{ terminal }}
+     return 5;
+     terminal;
+  */
+
+  /* Basic Blocks : 
+     B1 = [int a =4; return 6;]
+     B2 = [ goto {{ terminal }} ]
+     B3 = [ return 5; ]
+  */
+
+  // Create Start Block 
+  E(env.StartBlock("entry"s));
+
+  // Create immutable `a`, such that, `a` = 4
+  E(env.CreateImmutableVariable("a"s, FixpointType::GetIntType(), { "__value == 4"}));
+
+  // Create mutable variable `return`
+  E(env.CreateMutableOutputVariable("return"s, FixpointType::GetIntType(), { "__value == 6"}));
+
+  // Create mutable variable `b`
+  E(env.CrateMutableVariable("b"s, FixpointType::GetIntType(), { "__value < 7" }));
+    
+  // Create mutable variable `cmp` for branching information
+  E(env.CreateMutableVariable("cmp"s, FixpointType:GeetBoolType(), {}, format(env, "__value <=> {{a}} = 5"s)));
+
+  // Add Branching information
+  E(env.AddBranchInformation("cmp"s, true, "if.then"s));
+  E(env.AddBranchInformation("cmp"s, false, "if.end"s));
+
+  // Create the "if.then" block
+  E(env.StartBlock("if.then"s));
+  E(env.AssignMutableVariable("b"s, format(env, "__value == 5"s)));
+  E(env.addJumpInformation("if.end"s));
+
+  // Create the "if.end" block 
+  E(env.StartBlock("if.end"s));
+  // Create the Phi-Node
+  E(env.CreatePhiNode("d"s, FixpointType::GetIntType(), { "return"s, "b"s }, { "entry"s, "if.then"s }));
+  E(env.AssignMutableVariable("return", format(env, "__value = {{d}}"s)));
+
+  // Check for failure, and verify this works; or fail and be loud
+  E(env.ToStringOrFailure(str));
+
+  std::cout << "Succeeded:" << std::endl << str;
+  return 0;
+
+errh:
+  std::cout << "Failed:" << std::endl << str;
+  return -1;
+}
+  
+  
+  
+  

--- a/tools/liquidTypes-varibleEnvLib-example/VariableEnvLib_IfExampleTwo.cpp
+++ b/tools/liquidTypes-varibleEnvLib-example/VariableEnvLib_IfExampleTwo.cpp
@@ -1,5 +1,5 @@
 #include "llvm/Transforms/LiquidTypes/VariablesEnvironment.h"
-#include "llvm/Transforms/LiquidTypes/FunctionBlockgraph.h"
+#include "llvm/Transforms/LiquidTypes/FunctionBlockGraph.h"
 #include "llvm/Transforms/LiquidTypes/ResultType.h"
 #include <regex>
 #include <iostream>
@@ -38,7 +38,7 @@ public:
     return ResultType::Success();
   }
 
-  ResultType StrictlyDominates(const std::string& firstblockName, const std::string& secondBlockName, bool& result) const
+  ResultType StrictlyDominates(const std::string& firstBlockName, const std::string& secondBlockName, bool& result) const
   {
     result = (firstBlockName == "entry" && secondBlockName != "entry");
     return ResultType::Success();
@@ -86,13 +86,13 @@ int ifThenElseExample()
   E(env.StartBlock("entry"s));
 
   // Create immutable `a`, such that, `a` = 4
-  E(env.CreateImmutableVariable("a"s, FixpointType::GetIntType(), { "__value == 4" }));
+  E(env.CreateImmutableVariable("a"s, FixpointType::GetIntType(), {}, format(env, "__value == 4"s )));
 
   // Create mutable variable `return`
   E(env.CreateMutableOutputVariable("return"s, FixpointType::GetIntType(), { "__value == 6" }));
 
   // Create mutable variable `b`
-  E(env.CreateMutableVariable("b"s, FixpointType::GetIntType(), { "__value < 7" }));
+  E(env.CreateMutableVariable("b"s, FixpointType::GetIntType(), { "__value < 7" }, format(env, "__value == 5"s)));
     
   // Create mutable variable `cmp` for branching information
   E(env.CreateMutableVariable("cmp"s, FixpointType::GetBoolType(), {}, format(env, "__value <=> {{a}} == 4"s)));
@@ -104,7 +104,7 @@ int ifThenElseExample()
   // Create the "if.then" block
   E(env.StartBlock("if.then"s));
   E(env.AssignMutableVariable("b"s, format(env, "__value == 5"s)));
-  E(env.addJumpInformation("if.end"s));
+  E(env.AddJumpInformation("if.end"s));
 
   // Create the "if.end" block 
   E(env.StartBlock("if.end"s));
@@ -121,10 +121,5 @@ int ifThenElseExample()
 errh:
   std::cout << "Failed:" << std::endl << str;
   return -1;
-}
-
-int main()
-{
-  ifThenElseExample();
 }
 

--- a/tools/liquidTypes-varibleEnvLib-example/VariableEnvLib_IfExampleTwo.cpp
+++ b/tools/liquidTypes-varibleEnvLib-example/VariableEnvLib_IfExampleTwo.cpp
@@ -77,9 +77,9 @@ int ifThenElseExample()
   */
 
   /* Basic Blocks : 
-     B1 = [int a =4; return 6;]
-     B2 = [ goto {{ terminal }} ]
-     B3 = [ return 5; ]
+     B1 = [int a =4; .. return 6;]
+     B2 = [ return 5; ]
+     B3 = [ goto {{ terminal }} ]
   */
 
   // Create Start Block 
@@ -95,7 +95,7 @@ int ifThenElseExample()
   E(env.CrateMutableVariable("b"s, FixpointType::GetIntType(), { "__value < 7" }));
     
   // Create mutable variable `cmp` for branching information
-  E(env.CreateMutableVariable("cmp"s, FixpointType:GeetBoolType(), {}, format(env, "__value <=> {{a}} = 5"s)));
+  E(env.CreateMutableVariable("cmp"s, FixpointType::GetBoolType(), {}, format(env, "__value <=> {{a}} == 4"s)));
 
   // Add Branching information
   E(env.AddBranchInformation("cmp"s, true, "if.then"s));

--- a/tools/liquidTypes-varibleEnvLib-example/VariableEnvLib_IfExampleTwo.cpp
+++ b/tools/liquidTypes-varibleEnvLib-example/VariableEnvLib_IfExampleTwo.cpp
@@ -86,13 +86,13 @@ int ifThenElseExample()
   E(env.StartBlock("entry"s));
 
   // Create immutable `a`, such that, `a` = 4
-  E(env.CreateImmutableVariable("a"s, FixpointType::GetIntType(), {}, format(env, "__value == 4"s )));
+  E(env.CreateImmutableInputVariable("a"s, FixpointType::GetIntType(), { "__value == 4"s }));
 
   // Create mutable variable `return`
-  E(env.CreateMutableOutputVariable("return"s, FixpointType::GetIntType(), { "__value == 6" }));
+  E(env.CreateMutableOutputVariable("return"s, FixpointType::GetIntType(), { "__value == 5" }));
 
   // Create mutable variable `b`
-  E(env.CreateMutableVariable("b"s, FixpointType::GetIntType(), { "__value < 7" }, format(env, "__value == 5"s)));
+  E(env.CreateMutableVariable("b"s, FixpointType::GetIntType(), {}, format(env, "__value == 6"s)));
     
   // Create mutable variable `cmp` for branching information
   E(env.CreateMutableVariable("cmp"s, FixpointType::GetBoolType(), {}, format(env, "__value <=> {{a}} == 4"s)));
@@ -109,7 +109,7 @@ int ifThenElseExample()
   // Create the "if.end" block 
   E(env.StartBlock("if.end"s));
   // Create the Phi-Node
-  E(env.CreatePhiNode("d"s, FixpointType::GetIntType(), { "return"s, "b"s }, { "entry"s, "if.then"s }));
+  E(env.CreatePhiNode("d"s, FixpointType::GetIntType(), { "b"s, "b"s }, { "entry"s, "if.then"s }));
   E(env.AssignMutableVariable("return", format(env, "__value = {{d}}"s)));
 
   // Check for failure, and verify this works; or fail and be loud

--- a/tools/liquidTypes-varibleEnvLib-example/VariableEnvLib_IfExampleTwo.cpp
+++ b/tools/liquidTypes-varibleEnvLib-example/VariableEnvLib_IfExampleTwo.cpp
@@ -40,7 +40,7 @@ public:
 
   ResultType StrictlyDominates(const std::string& firstblockName, const std::string& secondBlockName, bool& result) const
   {
-    result = (firstblockName == "entry" && secondBlockName != "entry");
+    result = (firstBlockName == "entry" && secondBlockName != "entry");
     return ResultType::Success();
   }
 };
@@ -50,7 +50,7 @@ std::string format(VariablesEnvironment& env, std::string expression);
 #define E(exp) \
 {\
   ResultType a = exp; \
-  if (!a.Succeeded) { str = a.ErrorMsg goto errh;}\
+  if (!a.Succeeded) { str = a.ErrorMsg; goto errh; } \
 }
 
 int ifThenElseExample()
@@ -61,8 +61,8 @@ int ifThenElseExample()
      if (a == 4) { b = 5; } else { b = 6; }
      int b {__value == 5}
   */
-  LLVMFunctionBlockGraph_If llvmFunctionBlockGraph;
-  Variablesenvironment env(llvmFunctionBlockGraph);
+  LLVMFunctionBlockGraph_IfTwo llvmFunctionBlockGraph;
+  VariablesEnvironment env(llvmFunctionBlockGraph);
 
   std::string str;
 
@@ -77,7 +77,7 @@ int ifThenElseExample()
   */
 
   /* Basic Blocks : 
-     B1 = [int a =4; .. return 6;]
+     B1 = [int a = 4; .. return 6;]
      B2 = [ return 5; ]
      B3 = [ goto {{ terminal }} ]
   */
@@ -86,13 +86,13 @@ int ifThenElseExample()
   E(env.StartBlock("entry"s));
 
   // Create immutable `a`, such that, `a` = 4
-  E(env.CreateImmutableVariable("a"s, FixpointType::GetIntType(), { "__value == 4"}));
+  E(env.CreateImmutableVariable("a"s, FixpointType::GetIntType(), { "__value == 4" }));
 
   // Create mutable variable `return`
-  E(env.CreateMutableOutputVariable("return"s, FixpointType::GetIntType(), { "__value == 6"}));
+  E(env.CreateMutableOutputVariable("return"s, FixpointType::GetIntType(), { "__value == 6" }));
 
   // Create mutable variable `b`
-  E(env.CrateMutableVariable("b"s, FixpointType::GetIntType(), { "__value < 7" }));
+  E(env.CreateMutableVariable("b"s, FixpointType::GetIntType(), { "__value < 7" }));
     
   // Create mutable variable `cmp` for branching information
   E(env.CreateMutableVariable("cmp"s, FixpointType::GetBoolType(), {}, format(env, "__value <=> {{a}} == 4"s)));
@@ -122,7 +122,9 @@ errh:
   std::cout << "Failed:" << std::endl << str;
   return -1;
 }
-  
-  
-  
-  
+
+int main()
+{
+  ifThenElseExample();
+}
+

--- a/tools/liquidTypes-varibleEnvLib-example/VariableEnvLib_LoopExample.cpp
+++ b/tools/liquidTypes-varibleEnvLib-example/VariableEnvLib_LoopExample.cpp
@@ -91,10 +91,10 @@ int forLoopExample()
   E(env.StartBlock("entry"s));
 
   // Create mutable `i`
-  E(env.CreateMutableVariable("i"s, FixpointType::GetIntType(), { "__value <= 2147483647"s }, true));
+  E(env.CreateMutableVariable("i"s, FixpointType::GetIntType(), { "__value <= 2147483647"s }, "true"));
 
   // Create mutable variable `return`
-  E(env.CreateMutableVariable("return"s, FixpointType::GetIntType(), { "__value == 5"s }, true));
+  E(env.CreateMutableVariable("return"s, FixpointType::GetIntType(), { "__value == 5"s }, "true"));
 
   // Create mutable variable `i_one`
   E(env.CreateMutableVariable("i_one"s, FixpointType::GetIntType(), {}, format(env, "__value == 0"s )));

--- a/tools/liquidTypes-varibleEnvLib-example/VariableEnvLib_LoopExample.cpp
+++ b/tools/liquidTypes-varibleEnvLib-example/VariableEnvLib_LoopExample.cpp
@@ -128,4 +128,3 @@ errh:
   std::cout << "Failed:" << std::endl << str;
   return -1;
 }
-  

--- a/tools/liquidTypes-varibleEnvLib-example/VariableEnvLib_LoopExample.cpp
+++ b/tools/liquidTypes-varibleEnvLib-example/VariableEnvLib_LoopExample.cpp
@@ -133,11 +133,5 @@ int main()
 {
   forLoopExample();
 }
-
-
-  
-  
-
-
   
   

--- a/tools/liquidTypes-varibleEnvLib-example/VariableEnvLib_LoopExample.cpp
+++ b/tools/liquidTypes-varibleEnvLib-example/VariableEnvLib_LoopExample.cpp
@@ -40,7 +40,7 @@ public:
 
   ResultType StrictlyDominates(const std::string& firstBlockName, const std::string& secondBlockName, bool& result) const
   {
-    result = (firstBlockName == "entry" && secondBlockName != "entry") || (firstBlockName == "if.loop" && (secondBlockName != "if.loop" && secondBlockName != "entry"));
+    result = ((firstBlockName == "entry" && secondBlockName != "entry") || (firstBlockName == "if.loop" && (secondBlockName != "if.loop" && secondBlockName != "entry")));
     return ResultType::Success();
   }
 };
@@ -93,9 +93,6 @@ int forLoopExample()
 
   // Create mutable variable `i_one`
   E(env.CreateMutableVariable("i_one"s, FixpointType::GetIntType(), {}, format(env, "__value == 0"s )));
-
-  // Create mutable variable `temp`
-  E(env.CreateMutableVariable("temp"s, FixpointType::GetIntType(), {}, format(env, "__value == 0"s)));
 
   // Jump to the next block
   E(env.AddJumpInformation("if.loop"s));

--- a/tools/liquidTypes-varibleEnvLib-example/VariableEnvLib_LoopExample.cpp
+++ b/tools/liquidTypes-varibleEnvLib-example/VariableEnvLib_LoopExample.cpp
@@ -106,8 +106,8 @@ int forLoopExample()
   E(env.CreateMutableVariable("cmp"s, FixpointType::GetBoolType(), {}, format(env, "__value <=> {{i_one}} < 20"s)));
 
   // Add Branching information
-  E(env.AddBranchInformation("cmp", true, "if.then"s));
-  E(env.AddBranchInformation("cmp", false, "if.end"s));
+  E(env.AddBranchInformation("cmp"s, true, "if.then"s));
+  E(env.AddBranchInformation("cmp"s, false, "if.end"s));
   
   // Create the "if.then" block
   E(env.StartBlock("if.then"s));
@@ -116,7 +116,7 @@ int forLoopExample()
 
   // Create the "if.end" block
   E(env.StartBlock("if.end"s));
-  E(env.AssignMutableVariable("return", format(env, "__value == {i}"s)));
+  E(env.AssignMutableVariable("return"s, format(env, "__value == {i}"s)));
 
   // Check for failure, and verify this works; or fail and be loud
   E(env.ToStringOrFailure(str));

--- a/tools/liquidTypes-varibleEnvLib-example/VariableEnvLib_LoopExample.cpp
+++ b/tools/liquidTypes-varibleEnvLib-example/VariableEnvLib_LoopExample.cpp
@@ -134,4 +134,3 @@ int main()
   forLoopExample();
 }
   
-  

--- a/tools/liquidTypes-varibleEnvLib-example/VariableEnvLib_LoopExample.cpp
+++ b/tools/liquidTypes-varibleEnvLib-example/VariableEnvLib_LoopExample.cpp
@@ -46,7 +46,7 @@ public:
 
   ResultType StrictlyDominates(const std::string& firstBlockName, const std::string& secondBlockName, bool& result) const
   {
-    result = (firstBlockName == "entry" && secondBlockName != "entry") || (firstBlockName == "if.then" && secondBlockName == "if.then");
+    result = (firstBlockName == "entry" && secondBlockName != "entry") || (firstBlockName == "condition" && (secondBlockName != "condition" && secondBlockName != "entry"));
     return ResultType::Success();
   }
 };

--- a/tools/liquidTypes-varibleEnvLib-example/VariableEnvLib_LoopExample.cpp
+++ b/tools/liquidTypes-varibleEnvLib-example/VariableEnvLib_LoopExample.cpp
@@ -1,5 +1,5 @@
 #include "llvm/Transforms/LiquidTypes/VariablesEnvironment.h"
-#include "llvm/Transforms/LiquidTypes/Functionblockgraph.h"
+#include "llvm/Transforms/LiquidTypes/FunctionBlockGraph.h"
 #include "llvm/Transforms/LiquidTypes/ResultType.h"
 #include <regex>
 #include <iostream>
@@ -93,13 +93,13 @@ int forLoopExample()
   E(env.StartBlock("entry"s));
 
   // Create mutable `i`
-  E(env.CreateMutableVariable("i"s, FixpointType::GetIntType(), { "__value <= 2147483647" }));
+  E(env.CreateMutableVariable("i"s, FixpointType::GetIntType(), {}, format(env, "__value <= 2147483647"s )));
 
   // Create mutable variable `return`
-  E(env.CreateMutableVariable("return"s, FixpointType::GetIntType(), { "__value == 20" }));
+  E(env.CreateMutableVariable("return"s, FixpointType::GetIntType(), {}, format(env, "__value == 20"s )));
 
   // Create mutable variable `i_one`
-  E(env.CreateMutableVariable("i_one"s, FixpointType::GetIntType(), { "__value == 0" }));
+  E(env.CreateMutableVariable("i_one"s, FixpointType::GetIntType(), {}, format(env, "__value == 0"s )));
 
   // Create the "condition" block
   E(env.StartBlock("condition"s));
@@ -127,10 +127,5 @@ int forLoopExample()
 errh:
   std::cout << "Failed:" << std::endl << str;
   return -1;
-}
-
-int main()
-{
-  forLoopExample();
 }
   

--- a/tools/liquidTypes-varibleEnvLib-example/VariableEnvLib_LoopExample.cpp
+++ b/tools/liquidTypes-varibleEnvLib-example/VariableEnvLib_LoopExample.cpp
@@ -91,10 +91,10 @@ int forLoopExample()
   E(env.StartBlock("entry"s));
 
   // Create mutable `i`
-  E(env.CreateMutableVariable("i"s, FixpointType::GetIntType(), { "__value <= 2147483647"s }, "true"));
+  E(env.CreateMutableVariable("i"s, FixpointType::GetIntType(), { "__value <= 2147483647"s }, format(env, "__value <= 2147483647"s)));
 
   // Create mutable variable `return`
-  E(env.CreateMutableVariable("return"s, FixpointType::GetIntType(), { "__value == 5"s }, "true"));
+  E(env.CreateMutableVariable("return"s, FixpointType::GetIntType(), { "__value == 5"s }, format(env, "__value == 5"s)));
 
   // Create mutable variable `i_one`
   E(env.CreateMutableVariable("i_one"s, FixpointType::GetIntType(), {}, format(env, "__value == 0"s )));
@@ -102,14 +102,17 @@ int forLoopExample()
   // Create mutable variable `temp` (to buffer for `i_one`)
   E(env.CreateMutableVariable("temp"s, FixpointType::GetIntType(), {}, format(env, "__value == {{i_one}}"s)));
 
+  // Create mutable `cmp` variable
+  E(env.CreateMutableVariable("cmp"s, FixpointType::GetBoolType(), {}, format(env, "__value <=> true"s)));
+
   // Jump to the next block
   E(env.AddJumpInformation("if.condition"s));
   
-  // Create the "if.loop" block
+  // Create the "if.condition" block
   E(env.StartBlock("if.condition"s));
 
   // Check if i_one < 20
-  E(env.CreateMutableVariable("cmp"s, FixpointType::GetBoolType(), {}, format(env, "__value <=> {{i_one}} < 20"s)));
+  E(env.AssignMutableVariable("cmp"s, format(env, "__value <=> {{i_one}} < 20"s)));
 
   // Add Branching Information
   E(env.AddBranchInformation("cmp"s, true, "for.body"s));

--- a/tools/liquidTypes-varibleEnvLib-example/VariableEnvLib_LoopExample.cpp
+++ b/tools/liquidTypes-varibleEnvLib-example/VariableEnvLib_LoopExample.cpp
@@ -1,0 +1,143 @@
+#include "llvm/Transforms/LiquidTypes/VariablesEnvironment.h"
+#include "llvm/Transforms/LiquidTypes/Functionblockgraph.h"
+#include "llvm/Transforms/LiquidTypes/ResultType.h"
+#include <regex>
+#include <iostream>
+
+using namespace liquid;
+using namespace std::literals::string_literals;
+
+class LLVMFunctionBlockGraph_ForLoop: public FunctionBlockGraph
+{
+public:
+  std::string GetStartingBlockName() const
+  {
+    return "entry"s;
+  }
+
+  ResultType GetSuccessorBlocks(const std::string& blockName, std::vector<std::string>& successorBlocks) const
+  {
+    if (blockName == "entry")
+    {
+      successorBlocks.emplace_back("condition");
+      successorBlocks.emplace_back("if.then");
+      successorBlocks.emplace_back("if.end");
+    }
+    else if (blockName == "condition")
+    {
+      successorBlocks.emplace_back("if.then");
+      successorBlocks.emplace_back("if.end");
+    }
+    else if (blockName == "if.then")
+    {
+      successorBlocks.emplace_back("condition");
+    }
+    else if (blockName == "if.end")
+    {
+
+    }
+    else
+    {
+      return ResultType::Error("NA");
+    }
+
+    return ResultType::Success();
+  }
+
+  ResultType StrictlyDominates(const std::string& firstBlockName, const std::string& secondBlockName, bool& result) const
+  {
+    result = (firstBlockName == "entry" && secondBlockName != "entry") || (firstBlockName == "if.then" && secondBlockName == "if.then");
+    return ResultType::Success();
+  }
+};
+
+std::string format(VariablesEnvironment& env, std::string expression);
+
+#define E(exp) \
+{\
+  ResultType a = exp; \
+  if (!a.Succeeded) { str = a.ErrorMsg; goto errh; } \
+}
+
+int forLoopExample()
+{
+  /* Code to Verify :
+     int i;
+     int j;
+     for (int i = 0; i < 20; i++)
+     {
+     }
+     j = i;
+  */
+  LLVMFunctionBlockGraph_ForLoop llvmFunctionBlockGraph;
+  VariablesEnvironment env(llvmFunctionBlockGraph);
+
+  std::string str;
+
+  /* Corresponding 3-address code :
+     int i;
+     int j;
+     int i' = 0;
+     if (i' < 20) goto {{ i' = i' + 1 }}
+     j = i;
+  */
+
+  /* Basic Blocks :
+     B1 = [int i; .. int i' = 0]
+     B2 = [if (i' < 20) goto {{ B4 }}]
+     B3 = [j = i]
+     B4 = [i' = i' + 1; goto {{ B2 }}]
+  */
+
+  // Create Start Block
+  E(env.StartBlock("entry"s));
+
+  // Create mutable `i`
+  E(env.CreateMutableVariable("i"s, FixpointType::GetIntType(), { "__value <= 2147483647" }));
+
+  // Create mutable variable `return`
+  E(env.CreateMutableVariable("return"s, FixpointType::GetIntType(), { "__value == 20" }));
+
+  // Create mutable variable `i_one`
+  E(env.CreateMutableVariable("i_one"s, FixpointType::GetIntType(), { "__value == 0" }));
+
+  // Create the "condition" block
+  E(env.StartBlock("condition"s));
+  E(env.CreateMutableVariable("cmp"s, FixpointType::GetBoolType(), {}, format(env, "__value <=> {{i_one}} < 20"s)));
+
+  // Add Branching information
+  E(env.AddBranchInformation("cmp", true, "if.then"s));
+  E(env.AddBranchInformation("cmp", false, "if.end"s));
+  
+  // Create the "if.then" block
+  E(env.StartBlock("if.then"s));
+  E(env.AssignMutableVariable("i_one"s, format(env, "__value == {{i_one}} + 1"s)));
+  E(env.AddJumpInformation("condition"s));
+
+  // Create the "if.end" block
+  E(env.StartBlock("if.end"s));
+  E(env.AssignMutableVariable("return", format(env, "__value == {i}"s)));
+
+  // Check for failure, and verify this works; or fail and be loud
+  E(env.ToStringOrFailure(str));
+
+  std::cout << "Succeeded:" << std::endl << str;
+  return 0;
+
+errh:
+  std::cout << "Failed:" << std::endl << str;
+  return -1;
+}
+
+int main()
+{
+  forLoopExample();
+}
+
+
+  
+  
+
+
+  
+  


### PR DESCRIPTION
# Changes
* Add two examples : 
    * `VariableEnvLib_IfExampleTwo.cpp` --> Mimics basic blocks with an `if-then-else` workflow
    * `VariableEnvLib_LoopExample.cpp`  --> Mimics a `for` loop followed by a faulty assignment
* Modifies `CMakeLists.txt` to include the above files
* Modifies `VariableEnvLib.cpp` to allow for running the 2 new examples
* Addition of `main()` functions for _all_ examples in : `VariableEnvLib_*.cpp`

# Testing
* **Not** yet tested. I will test by calling `build/bin/clang -S -O0 /path/to/example.cpp` once the PR is in a merge ready state.

cc : @shravanrn 
